### PR TITLE
Add go_package option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the initial connector IDL file
 - Added buf-based linting
 - Added a CHANGELOG.md file
+- Added a `go_package` option
 
 ### Updated

--- a/connector/v1/connector.proto
+++ b/connector/v1/connector.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 package connector.v1;
+option go_package = "connector/v1;connector";
 
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";


### PR DESCRIPTION
set go_package to "connector/v1;connector".

Note: the CI build will fail (expectedly) as the generated
go code has a different package name which the CI considers
a breaking change (correctly so)